### PR TITLE
PHP Fatal error when trying to run pantheon_apachesolr_update_6001

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.install
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.install
@@ -30,6 +30,7 @@ function pantheon_apachesolr_disable() {
 function pantheon_apachesolr_update_6001() {
   $ret = array();
   $schema = drupal_get_path('module', 'apachesolr') .'/schema.xml';
+  include_once drupal_get_path('module', 'apachesolr') . 'pantheon_apachesolr.module';
   $response = pantheon_apachesolr_update_schema($schema);
   $ret[] = array('success' => $response != NULL, 'query' => 'Response: '. print_r($response, 1));
 


### PR DESCRIPTION
The error below was triggered when running pantheon_apachesolr_update_6001 update.
```PHP Fatal error:  Call to undefined function pantheon_apachesolr_update_schema() in modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.install on line 33```