### PR TITLE
Update to pressflow/6 pressflow-6.43.124

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+Drupal 6.43 LTS, 2018-03-29
+-----------------------
+- Fixes bug from SA-CORE-2018-002 changes, update version.
+
+Drupal 6.41, Drupal 6.42
+-----------------------
+Skipped to bring version number in line with
+https://github.com/d6lts/drupal
+
+Drupal 6.40 Pressflow, 2018-03-28
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2018-002.
+
+Drupal 6.39 Pressflow, 2018-02-21
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2018-001.
 
 Drupal 6.38, 2016-02-24 - Final release
 ---------------------------------------

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -2307,6 +2307,8 @@ function _drupal_bootstrap_sanitize_input(&$input, $whitelist = array()) {
         $sanitized_keys = array_merge($sanitized_keys, _drupal_bootstrap_sanitize_input($input[$key], $whitelist));
       }
     }
+    // PHP 5.x will leave the array pointer at the end without this.
+    reset($input);
   }
 
   return $sanitized_keys;

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.40');
+define('VERSION', '6.43');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
This PR was created by the create-update-pr script.

For more information, see https://github.com/pressflow/6/releases/tag/pressflow-6.43.124

Instructions to test:

Create a new Drupal 6 site on Pantheon.
When site creation is finished, visit dashboard.
Switch to git mode.
Clone your site locally.
Apply the files from this PR on top of your local checkout.
git remote add drops-6 git@github.com:pantheon-systems/drops-6.git
git fetch drops-6
git merge drops-6/update-pressflow-6.43.124
Push your files back up to Pantheon.
Switch back to sftp mode.
Visit your site. Step through the installation process. Look for any problems.