### PR TITLE
[PRT-227] Update to MariaDB 10.4

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -5,5 +5,9 @@
 api_version: 1
 php_version: 7.2
 
+# See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
+database:
+  version: 10.3
+
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional


### PR DESCRIPTION
For details, see https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb

See also pantheon-systems/documentation#6928, which modifies that section.